### PR TITLE
Update zookeeper.spec

### DIFF
--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -47,7 +47,7 @@ mkdir -p $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service.d
 mkdir -p $RPM_BUILD_ROOT%{_conf_dir}/
 install -p -D -m 644 zookeeper-%{version}.jar $RPM_BUILD_ROOT%{_prefix}/zookeeper/
 install -p -D -m 644 lib/*.jar $RPM_BUILD_ROOT%{_prefix}/zookeeper/
-install -p -D -m 755 %{S:1} $RPM_BUILD_ROOT%{_unitdir}/
+install -p -D -m 644 %{S:1} $RPM_BUILD_ROOT%{_unitdir}/
 install -p -D -m 644 %{S:2} $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/zookeeper
 install -p -D -m 644 %{S:3} $RPM_BUILD_ROOT%{_conf_dir}/
 install -p -D -m 644 %{S:4} $RPM_BUILD_ROOT%{_conf_dir}/log4j.properties


### PR DESCRIPTION
Update unit file permission to fix systemd complain:

Feb 07 11:48:03 centos7vm1 systemd[1]: Configuration file /usr/lib/systemd/system/zookeeper.service is marked executable. Please remove executable permission bits. Proceeding anyway.